### PR TITLE
#8: Fixing intermittent task failures

### DIFF
--- a/triggerJenkinsJobTask/tests/_suite.ts
+++ b/triggerJenkinsJobTask/tests/_suite.ts
@@ -40,6 +40,20 @@ describe('Trigger Jenkins Job task tests', function () {
         done();
     });
 
+    it('should succeed with simple inputs and wait', function(done: Mocha.Done) {
+        this.timeout(50000);
+
+        let tp = path.join(__dirname, 'successWithWait.js');
+        let tr: ttm.MockTestRunner = new ttm.MockTestRunner(tp);
+
+        tr.run();
+        assert.strictEqual(tr.succeeded, true, 'should have succeeded');
+        assert.strictEqual(tr.warningIssues.length, 0, "should have no warnings");
+        assert.strictEqual(tr.errorIssues.length, 0, "should have no errors");
+        assert.strictEqual(tr.stdout.indexOf('Successfully triggered a Jenkins job https://jenkins.iktech.io/job/test') >= 0, true, "should display success message");
+        done();
+    });
+
     it('should succeed with simple inputs', function(done: Mocha.Done) {
         this.timeout(50000);
 

--- a/triggerJenkinsJobTask/tests/successWithWait.ts
+++ b/triggerJenkinsJobTask/tests/successWithWait.ts
@@ -1,0 +1,15 @@
+import ma = require('azure-pipelines-task-lib/mock-answer');
+import tmrm = require('azure-pipelines-task-lib/mock-run');
+import path = require('path');
+
+let taskPath = path.join(__dirname, '..', 'index.js');
+let tmr: tmrm.TaskMockRunner = new tmrm.TaskMockRunner(taskPath);
+
+console.log(`URL: ${process.env.JENKINS_URL}`);
+tmr.setInput('jenkinsJobUrl', process.env.JENKINS_URL ?? '');
+tmr.setInput('jenkinsUsername', process.env.JENKINS_USERNAME ?? '');
+tmr.setInput('jenkinsApiToken', process.env.JENKINS_API_TOKEN ?? '');
+tmr.setInput('authenticationToken', process.env.JOB_AUTHENTICATION_TOKEN ?? '');
+tmr.setInput('waitForResponse', 'true');
+
+tmr.run();


### PR DESCRIPTION
Removed currentNumber from the JobStatus type as unused. Ensured that both inProgress set to false and result are set to some non-null value prior to making decision on job success status